### PR TITLE
fix on 4.9 kernel

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,12 @@ concurrency:
 jobs:
   build:
     runs-on: buildjet-2vcpu-ubuntu-2204
+    strategy:
+      matrix:
+        kernel-version: [ "stable", "4.9" ]
+    env:
+      CI_KERNEL: ghcr.io/cilium/ci-kernels:${{ matrix.kernel-version }}
+
     steps:
     - uses: actions/checkout@v3
 

--- a/init.go
+++ b/init.go
@@ -86,7 +86,7 @@ var earlyMounts = mountTable{
 	{"tmpfs", "/dev/shm", "tmpfs", "mode=01777", unix.MS_NOSUID | unix.MS_NODEV | unix.MS_STRICTATIME, true},
 	{"tmpfs", "/tmp", "tmpfs", "mode=01777", unix.MS_NOSUID | unix.MS_NOEXEC | unix.MS_NODEV | unix.MS_STRICTATIME, true},
 	{"tmpfs", "/run", "tmpfs", "mode=01777", unix.MS_NOSUID | unix.MS_NODEV | unix.MS_STRICTATIME, true},
-	{"cgroup2", "/sys/fs/cgroup", "cgroup2", "nsdelegate,memory_recursiveprot", unix.MS_NOSUID | unix.MS_NOEXEC | unix.MS_NODEV, false},
+	// {"cgroup2", "/sys/fs/cgroup", "cgroup2", "nsdelegate,memory_recursiveprot", unix.MS_NOSUID | unix.MS_NOEXEC | unix.MS_NODEV, false},
 	{"bpf", "/sys/fs/bpf", "bpf", "mode=0700", unix.MS_NOSUID | unix.MS_NOEXEC | unix.MS_NODEV, false},
 	{"debugfs", "/sys/kernel/debug", "debugfs", "", unix.MS_NOSUID | unix.MS_NOEXEC | unix.MS_NODEV | unix.MS_RELATIME, false},
 	{"tracefs", "/sys/kernel/tracing", "tracefs", "", unix.MS_NOSUID | unix.MS_NOEXEC | unix.MS_NODEV | unix.MS_RELATIME, false},

--- a/init.go
+++ b/init.go
@@ -13,6 +13,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const default9POptions = "version=9p2000.L,trans=virtio,access=any,msize=1048576"
+
 type syscaller interface {
 	mount(*mountPoint) error
 	sync()
@@ -216,7 +218,7 @@ func minimalInit(sys syscaller, args []string) error {
 			err = sys.mount(&mountPoint{
 				tag, path,
 				"9p",
-				"version=9p2000.L,trans=virtio,access=any",
+				default9POptions,
 				0,
 				false, // ignored
 			})
@@ -348,7 +350,7 @@ func prepareRoot() error {
 	//    /host     9pfs
 
 	root := hostDir
-	err := mount(p9OverlayTag, overlayDir, "9p", unix.MS_RDONLY, "version=9p2000.L,trans=virtio,access=any")
+	err := mount(p9OverlayTag, overlayDir, "9p", unix.MS_RDONLY, default9POptions)
 	if errors.Is(err, unix.ENOENT) {
 		fmt.Fprintln(os.Stderr, "Not mounting overlay:", err)
 	} else if err != nil {

--- a/qemu.go
+++ b/qemu.go
@@ -657,7 +657,7 @@ func (*p9Root) KArgs() []string {
 	return []string{
 		"root=/dev/root",
 		"rootfstype=9p",
-		"rootflags=trans=virtio,version=9p2000.L",
+		"rootflags=" + default9POptions,
 	}
 }
 

--- a/testdata/vimto.txt
+++ b/testdata/vimto.txt
@@ -4,6 +4,7 @@ config kernel="${IMAGE}"
 # is forwarded correctly.
 vimto exec true
 ! vimto exec false
+! stderr warning
 
 # Flag overrides config file.
 ! vimto exec -vm.kernel ./bogus true


### PR DESCRIPTION
use 1MiB msize to mount 9pfs

    Old kernels use very small buffers to transfer files between host and guest
    and qemu will warn if that is the case. Bump the default to 1MiB.

fix booting v4.9 kernel

    cgroupfs on 4.9 doesn't support one of the option and returns EINVAL. Don't
    mount it from init, users can use a setup command to achieve the same.

    Add 4.9 to CI.
