### PR TITLE
fix caching bug

### DIFF
--- a/file.go
+++ b/file.go
@@ -20,14 +20,14 @@ func replaceFdWithFile(sys syscaller, fd int, file *os.File) error {
 	return nil
 }
 
-func flock(f *os.File, how int) error {
+func fcntlLock(f *os.File, cmd int, typ int16) error {
 	_, err := fileControl(f, func(fd uintptr) (struct{}, error) {
-		return struct{}{}, unix.Flock(int(fd), how)
+		lock := unix.Flock_t{
+			Type: typ,
+		}
+		return struct{}{}, unix.FcntlFlock(fd, cmd, &lock)
 	})
-	if err != nil {
-		return fmt.Errorf("flock: %w", err)
-	}
-	return nil
+	return err
 }
 
 func unixSocketpair() (*os.File, *os.File, error) {

--- a/main.go
+++ b/main.go
@@ -138,7 +138,11 @@ func execCmd(args []string) error {
 		}
 		defer cli.Close()
 
-		cache := newImageCache(cli)
+		cache, err := newImageCache(cli)
+		if err != nil {
+			return fmt.Errorf("image cache: %w", err)
+		}
+
 		oi, err := cache.Acquire(context.Background(), cfg.Kernel)
 		if err != nil {
 			return fmt.Errorf("retrieve kernel from OCI image: %w", err)

--- a/main_test.go
+++ b/main_test.go
@@ -57,7 +57,8 @@ func TestExecutable(t *testing.T) {
 		image = "ghcr.io/cilium/ci-kernels:stable"
 	}
 
-	cache := newImageCache(mustNewDockerClient(t))
+	cache, err := newImageCache(mustNewDockerClient(t))
+	qt.Assert(t, qt.IsNil(err))
 	img, err := cache.Acquire(context.Background(), image)
 	qt.Assert(t, qt.IsNil(err))
 	defer img.Release()


### PR DESCRIPTION
Testing many packages concurrently can create the following error:

    rename temporary directory: rename /tmp/1080010020
        /tmp/vimto/1000/...: file exists

This is because the caching code assumes that flock can be used to atomically switch between lock modes. However, this isn't the case. Another process may have come along and extracted the image already while we were waiting to acquire the exclusive lock.