### PR TITLE
misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@
 `vimto` is a virtual machine testing orchestrator for the Go toolchain. It allows you to easily run Go unit tests using a specific Linux kernel.
 
 ```shell
-go test -exec vimto -vm.kernel /path/to/vmlinuz .
+go test -exec vimto . -vm.kernel /path/to/vmlinuz
 ```
 
 It's possible to obtain the kernel from a container image (requires Docker).
 
 ```shell
-go test -exec vimto -vm.kernel example.org/reg/image:tag .
+go test -exec vimto . -vm.kernel example.org/reg/image:tag
 ```
 
 Finally, you can also use a path to a directory:
 
 ```shell
-go test -exec vimto -vm.kernel ./path/to/dir .
+go test -exec vimto . -vm.kernel ./path/to/dir
 ```
 
 `vimto` expects the kernel to be at `/boot/vmlinuz` for containers and directories.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 )
 
 require (
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
@@ -108,6 +110,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=

--- a/init.go
+++ b/init.go
@@ -304,7 +304,7 @@ func executeSimpleCommands(cmds []configCommand, dir string, env []string) error
 		cmd.Stdout = os.Stdout
 		cmd.WaitDelay = time.Second
 		if err := cmd.Run(); err != nil {
-			return err
+			return fmt.Errorf("%s: %w", cmd.Path, err)
 		}
 	}
 	return nil

--- a/testdata/lifecycle.txt
+++ b/testdata/lifecycle.txt
@@ -3,3 +3,11 @@ config kernel="${IMAGE}" 'setup=["touch ''foo bar''"]' 'teardown=["rm ''foo bar'
 # Setup and teardown programs are executed.
 vimto exec -- stat 'foo bar'
 ! exists foo
+
+config kernel="${IMAGE}" 'setup=["/bin/false"]'
+! vimto exec -- true
+stderr /bin/false
+
+config kernel="${IMAGE}" 'teardown=["/bin/false"]'
+! vimto exec -- true
+stderr /bin/false


### PR DESCRIPTION
make it clear which command fails during setup and tear down

readme: move flags around

    Putting -vm.kernel at the front of the command line makes the go test tool
    stop parsing the command line. Move the flag to the back.

go mod tidy

