### PR TITLE
fix cache bug, 2nd try

### DIFF
--- a/file.go
+++ b/file.go
@@ -78,7 +78,7 @@ func fileControl[T any](f *os.File, fn func(fd uintptr) (T, error)) (T, error) {
 		return result, fmt.Errorf("control fd: %w", err)
 	}
 	if opErr != nil {
-		return result, err
+		return result, opErr
 	}
 
 	return result, nil

--- a/file.go
+++ b/file.go
@@ -20,12 +20,9 @@ func replaceFdWithFile(sys syscaller, fd int, file *os.File) error {
 	return nil
 }
 
-func fcntlLock(f *os.File, cmd int, typ int16) error {
+func flock(f *os.File, how int) error {
 	_, err := fileControl(f, func(fd uintptr) (struct{}, error) {
-		lock := unix.Flock_t{
-			Type: typ,
-		}
-		return struct{}{}, unix.FcntlFlock(fd, cmd, &lock)
+		return struct{}{}, unix.Flock(int(fd), how)
 	})
 	return err
 }

--- a/file_test.go
+++ b/file_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-quicktest/qt"
+	"golang.org/x/sys/unix"
 )
 
 func TestFileControl(t *testing.T) {
@@ -21,4 +22,21 @@ func TestFileControl(t *testing.T) {
 	})
 
 	qt.Assert(t, qt.ErrorIs(err, sentinel))
+}
+
+func TestFlock(t *testing.T) {
+	tmp := t.TempDir()
+	f1, err := os.Open(tmp)
+	qt.Assert(t, qt.IsNil(err))
+	defer f1.Close()
+
+	f2, err := os.Open(tmp)
+	qt.Assert(t, qt.IsNil(err))
+	defer f2.Close()
+
+	qt.Assert(t, qt.IsNil(flock(f1, unix.LOCK_SH)))
+	qt.Assert(t, qt.ErrorIs(flock(f2, unix.LOCK_EX|unix.LOCK_NB), unix.EWOULDBLOCK))
+
+	f1.Close()
+	qt.Assert(t, qt.IsNil(flock(f2, unix.LOCK_EX|unix.LOCK_NB)))
 }

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/go-quicktest/qt"
+)
+
+func TestFileControl(t *testing.T) {
+	f, err := os.CreateTemp("", "")
+	qt.Assert(t, qt.IsNil(err))
+	defer f.Close()
+	defer os.Remove(f.Name())
+
+	sentinel := errors.New("sentinel")
+
+	_, err = fileControl(f, func(fd uintptr) (struct{}, error) {
+		return struct{}{}, sentinel
+	})
+
+	qt.Assert(t, qt.ErrorIs(err, sentinel))
+}


### PR DESCRIPTION
fix caching bug, again

    The image cache was buggy since open file descriptor locks don't work on
    directories. This was obscured by a buggy fileControl method, and so the
    code behaved as if acquiring the lock always worked.

    Fix this by switching back to flock. Deal with the non-atomiticy of flock
    changes by revalidating that the contents directory doesn't exist.

fix fileControl

