### PR TITLE
allow disabling kvm

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  amd64:
     runs-on: buildjet-2vcpu-ubuntu-2204
     strategy:
       matrix:
@@ -39,3 +39,46 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+  arm64:
+    runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    strategy:
+      matrix:
+        kernel-version: [ "stable" ]
+    env:
+      CI_KERNEL: ghcr.io/cilium/ci-kernels:${{ matrix.kernel-version }}
+      VIMTO_DISABLE_KVM: "true"
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends qemu-system-aarch64
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...
+
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Results
+    needs:
+    - amd64
+    - arm64
+    steps:
+    - run: exit 1
+      if: >-
+        ${{
+              contains(needs.*.result, 'failure')
+          || contains(needs.*.result, 'cancelled')
+        }}

--- a/main_test.go
+++ b/main_test.go
@@ -44,6 +44,7 @@ func TestExecutable(t *testing.T) {
 			"XDG_",
 			"PATH=",
 			"HOME=",
+			"VIMTO_",
 		} {
 			if strings.HasPrefix(v, prefix) {
 				env = append(env, v)

--- a/testdata/kvm.txt
+++ b/testdata/kvm.txt
@@ -1,0 +1,6 @@
+config kernel="${IMAGE}"
+
+# Ensure that running without KVM is supported.
+env VIMTO_DISABLE_KVM=true
+vimto exec true
+stderr 'KVM disabled'


### PR DESCRIPTION
allow disabling KVM

    It's very hard to come by environments with KVM support on arm64. Allow
    disabling KVM via an environment variable so that we can still run tests on
    CI.

test on arm64

