### PR TITLE
Fix readonly param

### DIFF
--- a/qemu.go
+++ b/qemu.go
@@ -684,9 +684,14 @@ type p9SharedDirectory struct {
 }
 
 func (p9sd *p9SharedDirectory) Cmdline() []string {
+	readOnly := "off"
+	if p9sd.ReadOnly {
+		readOnly = "on"
+	}
+
 	return []string{
 		// Need security_model=none due to https://gitlab.com/qemu-project/qemu/-/issues/173
-		"-fsdev", fmt.Sprintf("local,id=%s,path=%s,readonly=%t,security_model=none,multidevs=remap", p9sd.ID, p9sd.Path, p9sd.ReadOnly),
+		"-fsdev", fmt.Sprintf("local,id=%s,path=%s,readonly=%s,security_model=none,multidevs=remap", p9sd.ID, p9sd.Path, readOnly),
 		"-device", fmt.Sprintf("virtio-9p-pci,fsdev=%s,mount_tag=%s", p9sd.ID, p9sd.Tag),
 	}
 }


### PR DESCRIPTION
The param takes the on/off values, but %t formats the boolean as true/false.

Error before this commit:

```
qemu-system-x86_64: -fsdev local,id=sd-9p-0,path=/tmp/go-build1305099592/b001,readonly=false,security_model=none,multidevs=remap: Parameter 'readonly' expects 'on' or 'off'
Error: exec: qemu: exit status 1
```