### PR TITLE
use ephemeral root filesystem in the vm

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,62 @@
+# Execution environment
+
+When developing new code for cilium/ebpf I usually iterate as follows:
+
+1. Run tests using `go test -exec sudo` on the host kernel.
+   Step through code using dlv (only works for some tests, sudo is cumbersome).
+2. Run tests using `go test -exec vimto` on a specific kernel. This is mostly to
+   mimic CI without having to push to GitHub.
+3. Very rarely, debug using dlv or gdb using a specific kernel. This is to catch
+   those pesky kernel bugs.
+
+vimto should therefore support the following tasks with minimal setup or interaction
+required by the user:
+
+- Execute a set of Go unit tests against a pre-compiled kernel.
+- Debugging Go unit tests with delve using a pre-comiled kernel.
+- Execute Go unit tests using a kernel which is debugged by gdb.
+
+The execution environment should be as close as possible to using `-exec sudo`
+so that the "ladder of iteration" doesn't require much context switching.
+
+- The host operating system already has all the necessary dependencies for unit tests.
+- Debug tooling like gdb and delve are taken from the host filesystem.
+- Kernel and modules are retrieved from an OCI image.
+
+## Filesystems
+
+The root filesystem is a merge of the following host paths.
+
+| Path              | Permissions | Comment                           |
+|-------------------|-------------|-----------------------------------|
+| /                 | r/o         | Root of the host operating system |
+| /boot, /usr, /lib | r/o         | Kernel and modules from OCI image |
+
+The root filesystem inside the VM is writable, but changes are ephemeral and not
+carried over to the host. This is because the root fs is shared by multiple VMs.
+Some system relevant filesystems like /sys, /proc and so on are private to the VM.
+
+The following paths are shared between the host and the VM:
+
+| Path                 | Comment                                          |
+|----------------------|--------------------------------------------------|
+| /tmp/path/to/workdir | Temporary files used by the Go toolchain (-work) |
+| /path/to/repository  | Root of the VCS repository                       |
+
+## User and group
+
+By default, commands execute as the current user and group. This works because
+/etc is shared between the host and the VM.
+
+It's possible to opt into running a command inside the VM as if it was invoked
+via `sudo --preserve-env`. This is not straight up sudo since the user might not
+have sudo privileges on the host.
+
+## Environment variables
+
+All variables from the environment are copied verbatim into the VM. PATH from
+outside the VM does take effect when looking up binaries.
+
+## Working directory
+
+The working directory is preserved in the VM.

--- a/main.go
+++ b/main.go
@@ -172,19 +172,28 @@ func execCmd(args []string) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
+	// Ensure that the repository root is available in the VM.
+	var sharedDirectories []string
+	if repo, err := findGitRoot("."); err != nil {
+		return err
+	} else if repo != "" {
+		sharedDirectories = append(sharedDirectories, repo)
+	}
+
 	cmd := &command{
-		Kernel:      vmlinuz,
-		Memory:      cfg.Memory,
-		SMP:         cfg.SMP,
-		Path:        fs.Arg(0),
-		Args:        fs.Args(),
-		User:        cfg.User,
-		Stdin:       os.Stdin,
-		Stdout:      os.Stdout,
-		Stderr:      os.Stderr,
-		RootOverlay: rootOverlay,
-		Setup:       cfg.Setup,
-		Teardown:    cfg.Teardown,
+		Kernel:            vmlinuz,
+		Memory:            cfg.Memory,
+		SMP:               cfg.SMP,
+		Path:              fs.Arg(0),
+		Args:              fs.Args(),
+		User:              cfg.User,
+		Stdin:             os.Stdin,
+		Stdout:            os.Stdout,
+		Stderr:            os.Stderr,
+		RootOverlay:       rootOverlay,
+		Setup:             cfg.Setup,
+		Teardown:          cfg.Teardown,
+		SharedDirectories: sharedDirectories,
 	}
 
 	if err := cmd.Start(ctx); err != nil {

--- a/testdata/go-test.txt
+++ b/testdata/go-test.txt
@@ -22,11 +22,20 @@ exec go test -exec vimto -run Success -race .
 # Add a test once we know what to do with this.
 # exec go test -exec "vimto arg" -run Success .
 
+# Building packages within the VM works.
+vimto exec go build -x .
+
 -- go.mod --
 
 module test
 
 go 1.21
+
+-- main.go --
+
+package main
+
+func main() {}
 
 -- main_test.go --
 


### PR DESCRIPTION
Many commands fail in the VM since the root filesystem is mounted read-only. For example, running go build inside the VM fails since the build cache can't be changed.

Rather than trying to track down every single case, use an ephemeral root filesystem inside the VM. Basically it behaves like a container, except that there is no way to persist the state.

There is one big risk here: an unsuspecting user might generate lots of changes to the root and run out of memory. To prevent this we limit the size of the ephemeral root to 25% of total RAM. After this limit is reached various syscalls will return ENOSPC. This is a lot easier to debug than random oomkills.