### PR TITLE
simplify invocation and improve UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,22 @@
 `vimto` is a virtual machine testing orchestrator for the Go toolchain. It allows you to easily run Go unit tests using a specific Linux kernel.
 
 ```shell
-go test -exec vimto . -vm.kernel /path/to/vmlinuz
+# With .vimto.toml in place:
+vimto -- go test .
+# Otherwise:
+vimto -kernel /path/to/vmlinuz -- go test .
 ```
 
 It's possible to obtain the kernel from a container image (requires Docker).
 
 ```shell
-go test -exec vimto . -vm.kernel example.org/reg/image:tag
+vimto -kernel example.org/reg/image:tag -- go test .
 ```
 
 Finally, you can also use a path to a directory:
 
 ```shell
-go test -exec vimto . -vm.kernel ./path/to/dir
+vimto -kernel /path/to/dir -- go test .
 ```
 
 `vimto` expects the kernel to be at `/boot/vmlinuz` for containers and directories.

--- a/config.go
+++ b/config.go
@@ -79,7 +79,7 @@ func parseConfigFromTOML(dir string, cfg *config) error {
 
 func configFlags(name string, cfg *config) *flag.FlagSet {
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
-	fs.Func("vm.kernel", "`path or url` to the Linux image (use ':tag' to substitute tag in url)", func(s string) error {
+	fs.Func("kernel", "`path or url` to the Linux image (use ':tag' to substitute tag in url)", func(s string) error {
 		if !strings.HasPrefix(s, ":") {
 			cfg.Kernel = s
 			return nil
@@ -97,15 +97,15 @@ func configFlags(name string, cfg *config) *flag.FlagSet {
 		cfg.Kernel = fmt.Sprintf("%s:%s", image, tag)
 		return nil
 	})
-	fs.Func("vm.memory", "memory to give to the VM", func(s string) error {
+	fs.Func("memory", "memory to give to the VM", func(s string) error {
 		cfg.Memory = s
 		return nil
 	})
-	fs.Func("vm.smp", "", func(s string) error {
+	fs.Func("smp", "", func(s string) error {
 		cfg.SMP = s
 		return nil
 	})
-	fs.BoolFunc("vm.sudo", "execute as root", func(s string) error {
+	fs.BoolFunc("sudo", "execute as root", func(s string) error {
 		if s != "true" {
 			return errors.New("flag only accepts true")
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -95,11 +95,11 @@ func TestConfigFlags(t *testing.T) {
 	fs := configFlags("test", &cfg)
 	fs.SetOutput(io.Discard)
 
-	err := fs.Parse([]string{"-vm.kernel", ":foo"})
+	err := fs.Parse([]string{"-kernel", ":foo"})
 	qt.Assert(t, qt.IsNotNil(err))
 
 	cfg.Kernel = "example.org/image:bar"
-	err = fs.Parse([]string{"-vm.kernel", ":foo"})
+	err = fs.Parse([]string{"-kernel", ":foo"})
 	qt.Assert(t, qt.IsNil(err))
 	qt.Assert(t, qt.Equals(cfg.Kernel, "example.org/image:foo"))
 }

--- a/file_test.go
+++ b/file_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/creack/pty/v2"
 	"github.com/go-quicktest/qt"
 	"golang.org/x/sys/unix"
 )
@@ -39,4 +40,27 @@ func TestFlock(t *testing.T) {
 
 	f1.Close()
 	qt.Assert(t, qt.IsNil(flock(f2, unix.LOCK_EX|unix.LOCK_NB)))
+}
+
+func TestFileIsTTY(t *testing.T) {
+	pty, tty, err := pty.Open()
+	qt.Assert(t, qt.IsNil(err))
+	defer pty.Close()
+	defer tty.Close()
+
+	ok, err := fileIsTTY(pty)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.Equals(ok, true))
+
+	ok, err = fileIsTTY(tty)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.Equals(ok, true))
+
+	dir, err := os.Open(t.TempDir())
+	qt.Assert(t, qt.IsNil(err))
+	defer dir.Close()
+
+	ok, err = fileIsTTY(dir)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.Equals(ok, false))
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/BurntSushi/toml v1.3.2
+	github.com/creack/pty/v2 v2.0.1
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/go-quicktest/qt v1.101.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/creack/pty/v2 v2.0.1 h1:RDY1VY5b+7m2mfPsugucOYPIxMp+xal5ZheSyVzUA+k=
+github.com/creack/pty/v2 v2.0.1/go.mod h1:2dSssKp3b86qYEMwA/FPwc3ff+kYpDdQI8osU8J7gxQ=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
 github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=

--- a/image.go
+++ b/image.go
@@ -60,7 +60,7 @@ func (ic *imageCache) Acquire(ctx context.Context, img string, status io.Writer)
 		return nil, err
 	}
 
-	return &image{path, lock}, nil
+	return &image{img, path, lock}, nil
 }
 
 func populateDirectoryOnce(path string, fn func(string) error) (lock *os.File, _ string, err error) {
@@ -126,12 +126,17 @@ func populateDirectoryOnce(path string, fn func(string) error) (lock *os.File, _
 }
 
 type image struct {
+	Name      string
 	Directory string
 	dir       *os.File
 }
 
 func (img *image) Close() error {
 	return img.dir.Close()
+}
+
+func (img *image) Kernel() string {
+	return filepath.Join(img.Directory, imageKernelPath)
 }
 
 func fetchImage(ctx context.Context, cli *docker.Client, refStr string, status io.Writer) (string, string, error) {

--- a/image.go
+++ b/image.go
@@ -44,6 +44,9 @@ func newImageCache(cli *docker.Client) (*imageCache, error) {
 	return &imageCache{cli, userCache}, nil
 }
 
+// Acquire an image from the cache.
+//
+// The image remains valid even after closing the cache.
 func (ic *imageCache) Acquire(ctx context.Context, img string) (_ *image, err error) {
 	refStr, digest, err := fetchImage(ctx, ic.cli, img)
 	if err != nil {
@@ -127,7 +130,7 @@ type image struct {
 	dir       *os.File
 }
 
-func (img *image) Release() error {
+func (img *image) Close() error {
 	return img.dir.Close()
 }
 

--- a/image_test.go
+++ b/image_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -18,12 +19,12 @@ func TestCacheAcquire(t *testing.T) {
 	cli := mustNewDockerClient(t)
 	cache := imageCache{cli, t.TempDir()}
 
-	img1, err := cache.Acquire(context.Background(), "busybox")
+	img1, err := cache.Acquire(context.Background(), "busybox", io.Discard)
 	qt.Assert(t, qt.IsNil(err))
 	defer img1.Close()
 
 	start := time.Now()
-	img2, err := cache.Acquire(context.Background(), "busybox")
+	img2, err := cache.Acquire(context.Background(), "busybox", io.Discard)
 	delta := time.Since(start)
 	qt.Assert(t, qt.IsTrue(delta < 100*time.Millisecond))
 	qt.Assert(t, qt.IsNil(err))
@@ -38,7 +39,7 @@ func TestFetchAndExtractImage(t *testing.T) {
 
 	cli.ImageRemove(context.Background(), "busybox", types.ImageRemoveOptions{Force: true})
 
-	refStr, digest, err := fetchImage(context.Background(), cli, "busybox")
+	refStr, digest, err := fetchImage(context.Background(), cli, "busybox", io.Discard)
 	qt.Assert(t, qt.IsNil(err))
 
 	refStr2, digest2, err := imageID(context.Background(), cli, refStr)
@@ -116,7 +117,7 @@ func TestSecureJoin(t *testing.T) {
 
 func BenchmarkExtractImage(b *testing.B) {
 	cli := mustNewDockerClient(b)
-	refStr, _, err := fetchImage(context.Background(), cli, "busybox")
+	refStr, _, err := fetchImage(context.Background(), cli, "busybox", io.Discard)
 	qt.Assert(b, qt.IsNil(err))
 
 	b.ResetTimer()

--- a/image_test.go
+++ b/image_test.go
@@ -20,14 +20,14 @@ func TestCacheAcquire(t *testing.T) {
 
 	img1, err := cache.Acquire(context.Background(), "busybox")
 	qt.Assert(t, qt.IsNil(err))
-	defer img1.Release()
+	defer img1.Close()
 
 	start := time.Now()
 	img2, err := cache.Acquire(context.Background(), "busybox")
 	delta := time.Since(start)
 	qt.Assert(t, qt.IsTrue(delta < 100*time.Millisecond))
 	qt.Assert(t, qt.IsNil(err))
-	defer img2.Release()
+	defer img2.Close()
 
 	qt.Assert(t, qt.Equals(img2.Directory, img1.Directory))
 }

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func findKernel(kernel string) (vmlinuz, overlay string, cleanup func() error, e
 			return "", "", nil, fmt.Errorf("image cache: %w", err)
 		}
 
-		oi, err := cache.Acquire(context.Background(), kernel)
+		oi, err := cache.Acquire(context.Background(), kernel, os.Stdout)
 		if err != nil {
 			return "", "", nil, fmt.Errorf("retrieve kernel from OCI image: %w", err)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -59,7 +60,7 @@ func TestExecutable(t *testing.T) {
 
 	cache, err := newImageCache(mustNewDockerClient(t))
 	qt.Assert(t, qt.IsNil(err))
-	img, err := cache.Acquire(context.Background(), image)
+	img, err := cache.Acquire(context.Background(), image, io.Discard)
 	qt.Assert(t, qt.IsNil(err))
 	defer img.Close()
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -62,33 +61,11 @@ func TestExecutable(t *testing.T) {
 	qt.Assert(t, qt.IsNil(err))
 	img, err := cache.Acquire(context.Background(), image)
 	qt.Assert(t, qt.IsNil(err))
-	defer img.Release()
+	defer img.Close()
 
 	env = append(env, "IMAGE="+image)
 	env = append(env, "KERNEL="+filepath.Join(img.Directory, imageKernelPath))
 	env = append(env, fmt.Sprintf("UID=%d", os.Geteuid()))
 
 	scripttest.Test(t, context.Background(), e, env, "testdata/*.txt")
-}
-
-func TestSortFlags(t *testing.T) {
-	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	fs.Bool("bool", false, "")
-	fs.String("vm.kernel", "", "")
-
-	for _, tc := range []struct {
-		input, want []string
-	}{
-		{
-			[]string{"/foo/bar", "-bool", "-test.v", "-test.run", "XXX", "-vm.kernel", "flarp"},
-			[]string{"-bool", "-vm.kernel", "flarp", "/foo/bar", "-test.v", "-test.run", "XXX"},
-		},
-		{
-			[]string{"/tmp/TestExecutablego-test664702905/001/tmp/go-build1359646099/b001/test.test", "-test.paniconexit0", "-test.timeout=10m0s", "-test.run=Success", "-vm.kernel=testdata/vmlinuz", "-test.v=true", "."},
-			[]string{"-vm.kernel=testdata/vmlinuz", "/tmp/TestExecutablego-test664702905/001/tmp/go-build1359646099/b001/test.test", "-test.paniconexit0", "-test.timeout=10m0s", "-test.run=Success", "-test.v=true", "."},
-		},
-	} {
-		got := sortArgs(fs, tc.input)
-		qt.Assert(t, qt.DeepEquals(got, tc.want))
-	}
 }

--- a/proc.go
+++ b/proc.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// send SIGINT and wait for a while instead of SIGKILL.
+func commandWithGracefulTermination(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Cancel = func() error {
+		return cmd.Process.Signal(os.Interrupt)
+	}
+	cmd.WaitDelay = 500 * time.Millisecond
+	return cmd
+}

--- a/qemu.go
+++ b/qemu.go
@@ -148,7 +148,7 @@ func (cmd *command) Start(ctx context.Context) (err error) {
 	if !disableKVM {
 		devices = append(devices, qemu.ArbitraryArgs{"-enable-kvm"})
 	} else if cmd.Stderr != nil {
-		fmt.Fprintln(os.Stderr, "Warning: KVM disabled, performance will be limited.")
+		fmt.Fprintln(cmd.Stderr, "Warning: KVM disabled, performance will be limited.")
 	}
 
 	var binary string
@@ -302,7 +302,7 @@ func (cmd *command) Start(ctx context.Context) (err error) {
 		cmd.fakeStdin = fakeStdinHost
 	}
 
-	proc := exec.CommandContext(ctx, qemuArgs[0], qemuArgs[1:]...)
+	proc := commandWithGracefulTermination(ctx, qemuArgs[0], qemuArgs[1:]...)
 	proc.Stdin = stdin
 	proc.Stdout = cmd.Stdout
 	proc.Stderr = cmd.Stderr

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/creack/pty/v2"
+	"github.com/go-quicktest/qt"
+	"golang.org/x/sys/unix"
+)
+
+func TestQemuTTY(t *testing.T) {
+	t.Parallel()
+
+	pty, tty, err := pty.Open()
+	qt.Assert(t, qt.IsNil(err))
+	defer pty.Close()
+	defer tty.Close()
+
+	get := func(f *os.File) (*unix.Termios, error) {
+		return fileControl(f, func(fd uintptr) (*unix.Termios, error) {
+			return unix.IoctlGetTermios(int(fd), unix.TCGETS)
+		})
+	}
+
+	old, err := get(tty)
+	qt.Assert(t, qt.IsNil(err))
+
+	image := mustFetchKernelImage(t)
+
+	r, w, err := os.Pipe()
+	qt.Assert(t, qt.IsNil(err))
+	defer r.Close()
+	defer w.Close()
+
+	var stderr bytes.Buffer
+	cmd := command{
+		Kernel: image.Kernel(),
+		Memory: "128M",
+		SMP:    "cpus=1",
+		Path:   "sh",
+		Args:   []string{"sh", "-c", "echo a; sleep 60"},
+		Stdin:  tty,
+		Stdout: w,
+		Stderr: &stderr,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	qt.Assert(t, qt.IsNil(cmd.Start(ctx)))
+
+	// Make sure we get EOF if the VM exits.
+	qt.Assert(t, qt.IsNil(w.Close()))
+
+	// qemu changes the tty settings before changing signal handlers. Cancelling
+	// too early means that the process is killed immediately, which aborts
+	// the shutdown.
+	// Wait for the vm to write to stdout as a proxy for signal handlers
+	// being up.
+	_, err = r.Read(make([]byte, 1))
+	qt.Assert(t, qt.IsNil(err))
+
+	new, err := get(tty)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.Not(qt.Equals(*new, *old)), qt.Commentf("termios should change"))
+
+	cancel()
+
+	err = cmd.Wait()
+	if stderr.Len() > 0 {
+		t.Log(stderr.String())
+	}
+	qt.Assert(t, qt.ErrorIs(err, context.Canceled))
+
+	// Ensure that the tty settings were restored.
+	new, err = get(tty)
+	qt.Assert(t, qt.IsNil(err))
+	qt.Assert(t, qt.Equals(*new, *old), qt.Commentf("termios should be restored"))
+}

--- a/testdata/go-test.txt
+++ b/testdata/go-test.txt
@@ -1,22 +1,22 @@
 config kernel="${IMAGE}"
 
 # Exit status and stdout, stderr of tests is correctly forwarded.
-exec go test -exec vimto -run Success -v .
+vimto -- go test -run Success -v .
 stdout TestSuccess
 
-! exec go test -exec vimto -run Failure .
+! vimto -- go test -run Failure .
 stdout TestFailure
 
 # We can pass various command line arguments through the test runner.
-exec go test -exec vimto -run Success -vm.smp 2 .
-exec go test -exec vimto -run Success -vm.smp=2 .
+vimto -smp 2 -- go test -run Success  .
+vimto -smp=2 -- go test -run Success  .
 
 # Running a test with coverage enabled works.
-exec go test -exec vimto -run Success -coverprofile=cover.out .
+vimto -- go test -run Success -coverprofile=cover.out .
 exists cover.out
 
 # Running a test with race enabled works.
-exec go test -exec vimto -run Success -race .
+vimto -- go test -run Success -race .
 
 # TODO: -exec allows injecting arguments, which is not supported.
 # Add a test once we know what to do with this.

--- a/testdata/vimto.txt
+++ b/testdata/vimto.txt
@@ -7,7 +7,7 @@ vimto exec true
 ! stderr warning
 
 # Flag overrides config file.
-! vimto exec -vm.kernel ./bogus true
+! vimto -kernel ./bogus exec  true
 
 # Output is forwarded correctly.
 vimto exec sh -c 'echo testing'
@@ -18,18 +18,18 @@ stdout testing # we don't have separate stderr at the moment.
 
 # We can pass various command line arguments. Include flags which contain
 # their value separated with a '='.
-vimto exec -vm.smp 2 true
-vimto exec -vm.memory 96M true
+vimto -smp 2 exec true
+vimto -memory 96M exec true
 
 # Binaries are executed with the appropriate user.
 vimto exec -- id -u
 stdout ^${UID}$
 
-vimto exec -vm.sudo -- id -u
+vimto -sudo exec -- id -u
 stdout ^0$
 
 # vm.sudo doesn't accept arguments.
-! vimto exec -vm.sudo=false -- true
+! vimto -sudo=false exec -- true
 
 # Current working directory is preserved.
 vimto exec -- pwd


### PR DESCRIPTION
simplify invocation

    Invoking vimto goes via the -exec flag:

        go test -exec vimto ...

    This has the downside of running into the special rules that go test has for
    arguments. For example, the following doesn't work:

        go test -exec vimto -vm.kernel /path -run Foo ./bar

    go test stops parsing the command line args after -vm.kernel which leads to
    very confusing behaviour. The fix is to always add arguments to the end of
    the command line, but that is hard to remember and impossible to enforce 
    from our side. The user has to learn by error, which isn't great.

    Additionally, there is no way to provide the user feedback as to what vimto
    is doing, since go test buffers all output. For example, it might look like
    the program is hanging while we are downloading a large OCI image.

    Fix this by changing the way vimto is invoked. Instead of being called by go 
    test we call go test instead. The equivalent of the example above is now:

        vimto -kernel /path -- go test -run Foo ./bar

    A nice side effect is that flags are less awkward to write out.

give indication of docker pull progress

    Add a progress bar to indicate that a docker image pull is going on. This
    avoids confusion if the pull takes a long time.

fix restoring tty settings on ctrl-c

    qemu changes some settings when it detects that stdin is a TTY. 
    Specifically, it turns off echoing. On shutdown it restores the old 
    settings. However, this doesn't work when the process is interrupted with
    ctrl-c because we react to os.Interrupt by killing the qemu process. This
    means that there is no time for qemu to restore settings. The result is a
    broken shell that you can type into, but which doesn't echo anything.

    Fix this by "forwarding" ctrl-c to qemu by sending it os.Interrupt and 
    giving it a grace time to shut down. This allows restoring the terminal
    setting.
