### PR TITLE
add coredump support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ vimto -- go test .
 vimto -kernel /path/to/vmlinuz -- go test .
 ```
 
+The tests are executed inside an ephemeral VM, with an [execution environment](docs/environment.md) which mimics the host.
+
 It's possible to obtain the kernel from a container image (requires Docker).
 
 ```shell
@@ -24,7 +26,7 @@ vimto -kernel /path/to/dir -- go test .
 ```
 
 `vimto` expects the kernel to be at `/boot/vmlinuz` for containers and directories.
-See also [Container format](#container-format).
+See also [Container format](docs/container.md).
 
 ## Installation
 
@@ -40,30 +42,6 @@ CGO_ENABLED=0 go install lmb.io/vimto@latest
 
 All available options and their values are in [testdata/default.toml](./testdata/default.toml).
 
-## Container format
-
-The container (or directory) must contain a file `/boot/vmlinuz` which is used to boot the VM.
-
-Other files and directories in the container are merged with the host filesystem
-using an overlayfs mount inside the VM.
-
-### Error: directory /lib: shadows symlink on host
-
-This error is generated if the image contains a directory that would shadow
-important directories in the host:
-
-* /lib
-* /lib64
-* /bin
-* /sbin
-
-This happens when running on distributions that have completed a /usr merge. In
-this case these directories are symlinks on the host. Overlaying a directory from
-the image will make the symlink disappear.
-
-To work around the issue, place files in `/usr/lib`, ... and include your own
-`/lib -> /usr/lib` symlink in the image.
-
 ## Currently not supported
 
 * Networking
@@ -71,8 +49,10 @@ To work around the issue, place files in `/usr/lib`, ... and include your own
 
 ## Requirements
 
+* An `amd64` or `arm64` host
 * A recent version of `qemu` (8.1.3 is known to work)
 * A Linux kernel with the necessary configuration (>= 4.9 is known to work)
+* KVM (optional, see [VIMTO_DISABLE_KVM](docs/tips.md))
 * Docker (optional, to fetch kernels from OCI registries)
 
 Here is a non-exhaustive list of required Linux options:

--- a/docs/container.md
+++ b/docs/container.md
@@ -1,0 +1,23 @@
+# Container format
+
+The container (or directory) must contain a file `/boot/vmlinuz` which is used to boot the VM.
+
+Other files and directories in the container are merged with the host filesystem
+using an overlayfs mount inside the VM.
+
+## Error: directory /lib: shadows symlink on host
+
+This error is generated if the image contains a directory that would shadow
+important directories in the host:
+
+* /lib
+* /lib64
+* /bin
+* /sbin
+
+This happens when running on distributions that have completed a /usr merge. In
+this case these directories are symlinks on the host. Overlaying a directory from
+the image will make the symlink disappear.
+
+To work around the issue, place files in `/usr/lib`, ... and include your own
+`/lib -> /usr/lib` symlink in the image.

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -1,0 +1,25 @@
+# Tips
+
+## Disable KVM
+
+You can disable KVM by setting an environment variable:
+
+```
+VIMTO_DISABLE_KVM=true vimto ...
+```
+
+This can be useful on hosts where nested virtualisation is not available. It
+will be rather slow though.
+
+## Enable Go coredumps
+
+Sometimes a test inside the VM crashes or panics and debugging may be difficult.
+In that case you can enable collecting a core dump like so:
+
+```
+GOTRACEBACK=crash vimto -- go test ...
+```
+
+[`GOTRACEBACK`](https://pkg.go.dev/runtime) is interpreted by the Go runtime.
+`vimto` will preserve the test binaries if it detects a core dump. This allows
+you to collect the binary and the core dump in CI for later debugging.

--- a/testdata/coredumps.txt
+++ b/testdata/coredumps.txt
@@ -1,0 +1,10 @@
+config kernel="${IMAGE}"
+
+# Ensure that ulimit inside the VM is raised.
+vimto exec -- sh -c 'ulimit -c'
+stdout unlimited
+
+# Trigger a core dump inside the VM.
+! vimto exec -- timeout -s QUIT 0.1s sleep 10
+stdout 'dumped core'
+glob-exists core-*

--- a/testdata/go-test.txt
+++ b/testdata/go-test.txt
@@ -18,12 +18,13 @@ exists cover.out
 # Running a test with race enabled works.
 vimto -- go test -run Success -race .
 
-# TODO: -exec allows injecting arguments, which is not supported.
-# Add a test once we know what to do with this.
-# exec go test -exec "vimto arg" -run Success .
+# The test binary is preserved if a test crashes with a coredump.
+env GOTRACEBACK=crash
+! vimto -- go test -run Panic .
+exists test.test
 
 # Building packages within the VM works.
-vimto exec go build -x .
+vimto exec go build .
 
 -- go.mod --
 
@@ -49,4 +50,8 @@ func TestSuccess(t *testing.T) {
 
 func TestFailure(t *testing.T) {
 	t.Error("Groop, I implore thee, my foonting turlingdromes")
+}
+
+func TestPanic(t *testing.T) {
+	panic("oh no!")
 }


### PR DESCRIPTION
enable coredumps inside the vm

    Enable collection of coredumps inside the VM. This can aid debugging by 
    using GOTRACEBACK:

        GOTRACEBACK=crash vimto -- go test

    A panic in the testsuite (including a test timeout) then triggers a coredump
    which can be inspected using delve.

    The coredump is placed into the current working directory, alongside with
    the test binary (if invoked via go test).

update docs

