### PR TITLE
fix vimto exec for binaries in /tmp

### DIFF
--- a/init.go
+++ b/init.go
@@ -298,11 +298,11 @@ func minimalInit(sys syscaller, args []string) error {
 			},
 		}
 
-		if err := unix.Access(proc.Path, unix.R_OK); err != nil {
+		if err := unix.Access(proc.Path, unix.R_OK); err == unix.EACCES {
 			// QEMU limitation: the 9p implementation needs to be able to read the
 			// executable to be able to execute it in the VM.
 			// TODO: Might be able to avoid this using CAP_DAC_OVERRIDE or similar.
-			fmt.Fprintf(stdio, "%s is not readable, execution might fail with %q\n", cmd.Path, unix.EACCES)
+			fmt.Fprintf(stdio, "%s is not readable, execution might fail with %q\n", cmd.Path, err)
 		}
 
 		result := proc.Run()

--- a/init.go
+++ b/init.go
@@ -247,9 +247,11 @@ func minimalInit(sys syscaller, args []string) error {
 			}
 		}
 
+		// Setup environment variables.
 		for _, env := range cmd.Env {
-			if strings.HasPrefix(env, "PATH=") {
-				err := os.Setenv("PATH", strings.TrimPrefix(env, "PATH="))
+			key, value, _ := strings.Cut(env, "=")
+			if key == "PATH" {
+				err := os.Setenv("PATH", value)
 				if err != nil {
 					return err
 				}
@@ -455,6 +457,10 @@ func prepareRoot() error {
 
 	if err := unix.Chdir("/"); err != nil {
 		return fmt.Errorf("chdir: %w", err)
+	}
+
+	if err := unix.Chmod("/tmp", 01777); err != nil {
+		return fmt.Errorf("chmod /tmp: %w", err)
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func execCmd(cfg *config, args []string) error {
 	}
 
 	// Ensure that the binary is available in the VM.
-	path := flag.Arg(0)
+	path := fs.Arg(0)
 	sharedDirectories = append(sharedDirectories, filepath.Dir(path))
 
 	// Ensure that the working directory is available.
@@ -198,7 +198,7 @@ func execCmd(cfg *config, args []string) error {
 		Kernel:      vmlinuz,
 		Memory:      cfg.Memory,
 		SMP:         cfg.SMP,
-		Path:        fs.Arg(0),
+		Path:        path,
 		Args:        fs.Args(),
 		Dir:         wd,
 		User:        cfg.User,

--- a/main_test.go
+++ b/main_test.go
@@ -43,6 +43,19 @@ func TestExecutable(t *testing.T) {
 
 	e := script.NewEngine()
 	e.Cmds["glob-exists"] = globExists
+	e.Cmds["new-tmp"] = script.Command(script.CmdUsage{
+		Summary: "use a distinct temp directory",
+		Detail: []string{
+			"Create a new TMPDIR which is not a subdirectory of WORK.",
+		},
+	}, func(s *script.State, args ...string) (script.WaitFunc, error) {
+		if len(args) != 0 {
+			return nil, script.ErrUsage
+		}
+
+		s.Setenv("TMPDIR", t.TempDir())
+		return nil, nil
+	})
 	e.Cmds["vimto"] = script.Program("vimto", nil, time.Second)
 	e.Cmds["config"] = script.Command(script.CmdUsage{
 		Summary: "Write to the configuration file",

--- a/testdata/go-test.txt
+++ b/testdata/go-test.txt
@@ -1,4 +1,5 @@
 config kernel="${IMAGE}"
+new-tmp
 
 # Exit status and stdout, stderr of tests is correctly forwarded.
 vimto -- go test -run Success -v .


### PR DESCRIPTION
fix vimto exec for binaries in /tmp

    vimto exec fails for binaries in /tmp, because I introduced a bug into the
    shared directory code. This didn't trigger a failure in CI because we use a
    TMPDIR which is a subdirectory of the current working directory.

    Add a script helper which allocates a new TMPDIR and fix the bug.

fix incorrect TMPDIR in VM

    The VM currently inherits TMPDIR from the host environment. This doesn't
    make sense since we set up our own /tmp. Fix this by clearing TMPDIR and
    ensuring that /tmp is world writable.

only print warning on EACCES

    There is a heuristic which is meant to warn the user if the VM doesn't have
    read access to a file residing on 9pfs. Currently it also prints out the
    same warning if the file doesn't exist.

    Only print the warning if we get EACCES.
