### PR TITLE
gdb support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends qemu-system-x86
+        sudo apt-get install -y --no-install-recommends gdb qemu-system-x86
 
     - run: sudo chmod 0666 /dev/kvm
 
@@ -60,7 +60,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y --no-install-recommends qemu-system-aarch64
+        sudo apt-get install -y --no-install-recommends gdb qemu-system-aarch64
 
     - name: Build
       run: go build -v ./...

--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ type config struct {
 	Memory   string          `toml:"memory"`
 	SMP      string          `toml:"smp"`
 	User     string          `toml:"user"`
+	GDB      string          `toml:"-"`
 	Setup    []configCommand `toml:"setup"`
 	Teardown []configCommand `toml:"teardown"`
 }
@@ -111,6 +112,14 @@ func configFlags(name string, cfg *config) *flag.FlagSet {
 		}
 
 		cfg.User = "root"
+		return nil
+	})
+	fs.BoolFunc("gdb", "enable GDB server", func(s string) error {
+		if s != "true" {
+			return errors.New("flag only accepts true")
+		}
+
+		cfg.GDB = "localhost:1234"
 		return nil
 	})
 

--- a/config_test.go
+++ b/config_test.go
@@ -14,7 +14,7 @@ import (
 func TestParseConfigFromTOML(t *testing.T) {
 	tmp := t.TempDir()
 
-	want := &config{"A", "B", "C", "", nil, nil}
+	want := &config{"A", "B", "C", "", "", nil, nil}
 
 	have := *want
 	qt.Assert(t, qt.IsNil(parseConfigFromTOML(tmp, &have)))
@@ -31,7 +31,7 @@ memory = "bar"
 
 	qt.Assert(t, qt.IsNil(parseConfigFromTOML(tmp, &have)))
 	qt.Assert(t, qt.DeepEquals(&have, &config{
-		"foo", "bar", want.SMP, want.User, nil, nil,
+		Kernel: "foo", Memory: "bar", SMP: want.SMP,
 	}))
 }
 

--- a/docs/container.md
+++ b/docs/container.md
@@ -1,6 +1,11 @@
 # Container format
 
-The container (or directory) must contain a file `/boot/vmlinuz` which is used to boot the VM.
+The container must contain one of these files in order to boot the VM.
+
+1. `/boot/vmlinux`
+2. `/boot/vmlinuz`
+
+The first existing file is used.
 
 Other files and directories in the container are merged with the host filesystem
 using an overlayfs mount inside the VM.

--- a/image.go
+++ b/image.go
@@ -51,6 +51,10 @@ func (ic *imageCache) Acquire(ctx context.Context, img string, status io.Writer)
 		return nil, fmt.Errorf("fetch image: %w", err)
 	}
 
+	// Replace sha256:deadbeef with sha256@deadbeef to avoid colon being
+	// interpreted as a path separator.
+	digest = strings.Replace(digest, ":", "@", 1)
+
 	lock, path, err := populateDirectoryOnce(filepath.Join(ic.baseDir, digest), func(path string) error {
 		return extractImage(ctx, ic.cli, refStr, path)
 	})

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -38,7 +38,7 @@ func TestQemuTTY(t *testing.T) {
 
 	var stderr bytes.Buffer
 	cmd := command{
-		Kernel: image.Kernel(),
+		Kernel: image.Kernel,
 		Memory: "128M",
 		SMP:    "cpus=1",
 		Path:   "sh",

--- a/testdata/coredumps.txt
+++ b/testdata/coredumps.txt
@@ -1,4 +1,4 @@
-config kernel="${IMAGE}"
+config kernel="${KERNEL}"
 
 # Ensure that ulimit inside the VM is raised.
 vimto exec -- sh -c 'ulimit -c'

--- a/testdata/gdb.txt
+++ b/testdata/gdb.txt
@@ -1,0 +1,11 @@
+config kernel="${KERNEL}"
+
+vimto -gdb exec true &
+
+# The gdbstub is reachable and accepts commands.
+gdb localhost:1234 c
+stdout W00
+
+# Output contains instructions how to connect.
+wait
+stdout 'target remote'

--- a/testdata/go-test.txt
+++ b/testdata/go-test.txt
@@ -1,4 +1,4 @@
-config kernel="${IMAGE}"
+config kernel="${KERNEL}"
 new-tmp
 
 # Exit status and stdout, stderr of tests is correctly forwarded.

--- a/testdata/kvm.txt
+++ b/testdata/kvm.txt
@@ -1,4 +1,4 @@
-config kernel="${IMAGE}"
+config kernel="${KERNEL}"
 
 # Ensure that running without KVM is supported.
 env VIMTO_DISABLE_KVM=true

--- a/testdata/lifecycle.txt
+++ b/testdata/lifecycle.txt
@@ -1,13 +1,13 @@
-config kernel="${IMAGE}" 'setup=["touch ''foo bar''"]' 'teardown=["rm ''foo bar''"]'
+config kernel="${KERNEL}" 'setup=["touch ''foo bar''"]' 'teardown=["rm ''foo bar''"]'
 
 # Setup and teardown programs are executed.
 vimto exec -- stat 'foo bar'
 ! exists foo
 
-config kernel="${IMAGE}" 'setup=["/bin/false"]'
+config kernel="${KERNEL}" 'setup=["/bin/false"]'
 ! vimto exec -- true
 stderr /bin/false
 
-config kernel="${IMAGE}" 'teardown=["/bin/false"]'
+config kernel="${KERNEL}" 'teardown=["/bin/false"]'
 ! vimto exec -- true
 stderr /bin/false

--- a/testdata/oci.txt
+++ b/testdata/oci.txt
@@ -1,0 +1,3 @@
+# Load the kernel from an OCI image.
+config kernel="${IMAGE}"
+vimto exec true

--- a/testdata/vimto.txt
+++ b/testdata/vimto.txt
@@ -1,4 +1,4 @@
-config kernel="${IMAGE}"
+config kernel="${KERNEL}"
 
 # We can execute binary, with the kernel being read from the config. Exit status
 # is forwarded correctly.


### PR DESCRIPTION
image: rework atomic cache commit

    The image cache uses a "contents" directory to store the extracted image
    data. This makes it so that a manually extracted image is not a valid cache
    entry, and therefore the code has to deal with both separately.

    Rewrite the atomic cache commit so that it doesn't need the contents 
    directory anymore.

allow booting vmlinux in addition to vmlinuz


add gdb stub support

