### PR TITLE
Revert "work around race in virtio serial console"

### DIFF
--- a/qemu.go
+++ b/qemu.go
@@ -560,10 +560,7 @@ func (vios *virtioSerialPorts) Cmdline() []string {
 
 	args := []string{
 		// There seems to be an off by one error with max_ports.
-		//
-		// ioeventfd=off works around a weird race condition where writing to the serial
-		// console from inside the guest may get stuck waiting for a wakeup.
-		"-device", fmt.Sprintf("virtio-serial,max_ports=%d,ioeventfd=off", len(vios.Chardevs)+1),
+		"-device", fmt.Sprintf("virtio-serial,max_ports=%d", len(vios.Chardevs)+1),
 	}
 	for dev, name := range vios.Chardevs {
 		args = append(args,


### PR DESCRIPTION
This reverts commit 475850de399c51e7a39da10adb34dc6d54e9294f.

It seems that kernels < 6.1 suffer from a separate lost wakeup problem which manifests in reads of the control message timing out:

    [    1.312132] Run /home/runner/go/bin/vimto as init process
    Error: read command: read /dev/vport2p1: i/o timeout
    [    3.144910] ACPI: Preparing to enter system sleep state S5